### PR TITLE
Added "charset=utf8" to PDO initialization

### DIFF
--- a/src/Psecio/Gatekeeper/DataSource/Mysql.php
+++ b/src/Psecio/Gatekeeper/DataSource/Mysql.php
@@ -32,7 +32,7 @@ class Mysql extends \Psecio\Gatekeeper\DataSource
     public function buildPdo(array $config)
     {
         return new \PDO(
-            'mysql:dbname='.$config['name'].';host='.$config['host'],
+            'mysql:dbname='.$config['name'].';host='.$config['host'].';charset=utf8',
             $config['username'], $config['password']
         );
     }


### PR DESCRIPTION
This way non-latin characters are stored in database as is and not as garbage.
