### PR TITLE
Improve the composer requirements to use ranges

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         "php":">=5.4.0",
         "enygma/modler": "1.*",
         "robmorgan/phinx": "*",
-        "ircmaxell/password-compat": "1.0.4",
-        "ircmaxell/random-lib": "1.1.0",
+        "ircmaxell/password-compat": "^1.0.4",
+        "ircmaxell/random-lib": "^1.1.0",
         "vlucas/phpdotenv": "1.*",
-        "symfony/expression-language": "2.5.*@dev",
+        "symfony/expression-language": "^2.5",
         "monolog/monolog": "^1.13"
     },
     "require-dev": {


### PR DESCRIPTION
Using exact version constraints in requirements is a bad practice in libraries, because it makes them much harder to use: if the project does not use exactly that version of the library, it cannot use your library. And if it already uses your library, it cannot update the other one to benefit from a bug fix (or even potentially a security fix) until you make a new release compatible with it.

The worse requirement here was probably the `symfony/expression-language` one, as it was forcing to use an unmaintained version of Symfony to be compatible with your library.
