### PR TITLE
phpdotenv v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "robmorgan/phinx": "*",
         "ircmaxell/password-compat": "^1.0.4",
         "ircmaxell/random-lib": "^1.1.0",
-        "vlucas/phpdotenv": "1.*",
+        "vlucas/phpdotenv": "~2",
         "symfony/expression-language": "^2.5",
         "monolog/monolog": "^1.13"
     },

--- a/src/Psecio/Gatekeeper/Gatekeeper.php
+++ b/src/Psecio/Gatekeeper/Gatekeeper.php
@@ -240,7 +240,7 @@ class Gatekeeper
     protected static function loadDotEnv($envPath)
     {
         try {
-            \Dotenv::load($envPath);
+            \Dotenv\Dotenv::load($envPath);
             $config = array(
                 'username' => $_SERVER['DB_USER'],
                 'password' => $_SERVER['DB_PASS'],


### PR DESCRIPTION
phpdotenv is now at version 2+. There is no BC breakage going on from what I can see, so I recommend the dependency gets upped.
