### PR TITLE
Update composer.json Modler version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require":{
         "php":">=5.4.0",
-        "enygma/modler": "1.*",
+        "enygma/modler": "2.*",
         "robmorgan/phinx": "*",
         "ircmaxell/password-compat": "^1.0.4",
         "ircmaxell/random-lib": "^1.1.0",


### PR DESCRIPTION
Updated modler to newer version. All tests seem to pass. This is **VERY** important to update because modler is broken for Twig in its current state (no `isset`) and this would at least allow users to use `dev-master` of modler.
