### PR TITLE
Add InvalidArgumentException when an undefined column is used on a model

### DIFF
--- a/src/Psecio/Gatekeeper/DataSource/Mysql.php
+++ b/src/Psecio/Gatekeeper/DataSource/Mysql.php
@@ -145,6 +145,9 @@ class Mysql extends \Psecio\Gatekeeper\DataSource
         $properties = $model->getProperties();
 
         foreach ($bind as $column => $name) {
+            if (!isset($properties[$column]['column'])) {
+                throw new \InvalidArgumentException('Column "'.$column. '" is not defined!');
+            }
             $colName = $properties[$column]['column'];
             $update[] = $colName.' = '.$name;
         }


### PR DESCRIPTION
I ran into this issue quite a lot when doing upserting - turns out "groups" as a "column" can only be defined during registration, and subsequently only with `addGroup`. If this warning had been here, I would have realized what was to matter with the code much sooner.
